### PR TITLE
Add option to send data stream timestamp instead of host wall clock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 !**/Build/CMakeLists.txt
 !**/Build/CMAKE_README.txt
 
+# OS
+.DS_Store

--- a/Source/FalconOutput.cpp
+++ b/Source/FalconOutput.cpp
@@ -34,6 +34,7 @@ FalconOutput::FalconOutput()
     flag = 0;
     messageNumber = 0;
     port = 3335;
+    useDataTimestamp = false;
 
     if (! socket)
         createSocket();
@@ -54,6 +55,7 @@ void FalconOutput::registerParameters()
     addSelectedStreamParameter (Parameter::PROCESSOR_SCOPE, "stream", "Stream", "The stream to send", {}, 0, true, true);
     addMaskChannelsParameter (Parameter::STREAM_SCOPE, "channels", "Channels", "The input channel data to send", true);
     addIntParameter (Parameter::PROCESSOR_SCOPE, "data_port", "Port", "Port number to send data", port, 1000, 65535, true);
+    addBooleanParameter (Parameter::PROCESSOR_SCOPE, "use_data_timestamp", "Data Time", "Use timestamp from data stream instead of host wall-clock time", false, true);
 }
 
 void FalconOutput::createSocket()
@@ -194,7 +196,10 @@ void FalconOutput::process (AudioBuffer<float>& buffer)
             // Send the sample number of the first sample in the buffer block
             auto selectedChannels = static_cast<MaskChannelsParameter*> (stream->getParameter ("channels"))->getArrayValue();
             int64 sampleNum = getFirstSampleNumberForBlock (selectedStream);
-            double timestamp = double (Time::getHighResolutionTicks()) / double (Time::getHighResolutionTicksPerSecond());
+            // Either the source/data timestamp (same value written to disk by the Record Node) or the host wall clock, per the UI toggle.
+            double timestamp = useDataTimestamp
+                                   ? getFirstTimestampForBlock (selectedStream)
+                                   : double (Time::getHighResolutionTicks()) / double (Time::getHighResolutionTicksPerSecond());
             int numSamples = getNumSamplesInBlock (selectedStream);
             int numChannels = selectedChannels.size();
 
@@ -235,6 +240,10 @@ void FalconOutput::parameterValueChanged (Parameter* param)
     {
         int dataPort = static_cast<IntParameter*> (param)->getIntValue();
         setPort (dataPort);
+    }
+    else if (param->getName().equalsIgnoreCase ("use_data_timestamp"))
+    {
+        useDataTimestamp = static_cast<BooleanParameter*> (param)->getBoolValue();
     }
 }
 

--- a/Source/FalconOutput.h
+++ b/Source/FalconOutput.h
@@ -90,6 +90,7 @@ private:
     int flag;
     int messageNumber;
     uint32_t port;
+    bool useDataTimestamp;
     flatbuffers::FlatBufferBuilder flatBuilder;
 
     std::vector<uint16> eventCodes;

--- a/Source/FalconOutputEditor.cpp
+++ b/Source/FalconOutputEditor.cpp
@@ -31,17 +31,19 @@ FalconOutputEditor::FalconOutputEditor (GenericProcessor* parentNode) : GenericE
 
     desiredWidth = 190;
 
-    addSelectedStreamParameterEditor (Parameter::PROCESSOR_SCOPE, "stream", 15, 34);
-    addMaskChannelsParameterEditor (Parameter::STREAM_SCOPE, "channels", 15, 58);
-    addTextBoxParameterEditor (Parameter::PROCESSOR_SCOPE, "data_port", 15, 82);
+    addSelectedStreamParameterEditor (Parameter::PROCESSOR_SCOPE, "stream", 15, 30);
+    addMaskChannelsParameterEditor (Parameter::STREAM_SCOPE, "channels", 15, 50);
+    addTextBoxParameterEditor (Parameter::PROCESSOR_SCOPE, "data_port", 15, 70);
 
     ipAddressLabel = std::make_unique<Label> ("ipAddress", "Address");
-    ipAddressLabel->setBounds (123, 105, 55, 20);
+    ipAddressLabel->setBounds (123, 110, 55, 20);
     ipAddressLabel->setFont (FontOptions ("Inter", "Regular", 13));
     addAndMakeVisible (ipAddressLabel.get());
 
     ipAddress = std::make_unique<Label> ("ipAddress", IPAddress::getLocalAddress().toString());
-    ipAddress->setBounds (15, 105, 180, 20);
+    ipAddress->setBounds (13, 110, 180, 20);
+
+    addToggleParameterEditor (Parameter::PROCESSOR_SCOPE, "use_data_timestamp", 15, 90);
     addAndMakeVisible (ipAddress.get());
 
     for (auto ed : parameterEditors)

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -51,7 +51,7 @@ extern "C" EXPORT void getLibInfo (Plugin::LibraryInfo* info)
     info->name = "Falcon I/O";
 
     //Version of the library, used only for information
-    info->libVersion = "1.0.1";
+    info->libVersion = "1.1.0";
     info->numPlugins = NUM_PLUGINS;
 }
 


### PR DESCRIPTION
Adds a "Data Time" toggle to the plugin editor.

When disabled (default), the existing host wall-clock behaviour is preserved.
When enabled, the timestamp in each ZMQ packet matches the data stream's own timing.